### PR TITLE
maybe should use withStores.

### DIFF
--- a/src/copy/ExampleComponentWithNamespacedState.md
+++ b/src/copy/ExampleComponentWithNamespacedState.md
@@ -20,7 +20,7 @@ class MyComponent extends React.Component<StoreProps> {
   }
 }
 
-export default Store.withStore(MyComponent)
+export default Store.withStores(MyComponent)
 ```
 
 flow
@@ -46,7 +46,7 @@ class MyComponent extends React.Component<StoreProps> {
   }
 }
 
-export default Store.withStore(MyComponent)
+export default Store.withStores(MyComponent)
 ```
 
 es6
@@ -71,7 +71,7 @@ class MyComponent extends React.Component {
   }
 }
 
-export default Store.withStore(MyComponent)
+export default Store.withStores(MyComponent)
 ```
 
 es5
@@ -98,5 +98,5 @@ var MyComponent = createReactClass({
   }
 })
 
-module.exports = Store.withStore(MyComponent)
+module.exports = Store.withStores(MyComponent)
 ```


### PR DESCRIPTION
Today, I use createConnectedStoreAs. 
then, I read your example.
but It caused "withStore is not a function" Error.
I read your code.
Your code means I should use withStores.

I edit your example.
If you want us to use "withStores", please merge this request.

If you don't want it, please edit undux's source code.


undux is very usefull.
I love it.

I hope this will be used even more.
please forgive my bad English.